### PR TITLE
Fix discord oauth authentication flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,12 +16,8 @@ DATABASE_URL="file:./db.sqlite"
 BETTER_AUTH_SECRET=
 BETTER_AUTH_URL=
 
-# Discord OAuth (Server-side) - Required for Better Auth
-DISCORD_CLIENT_ID=
+# Discord OAuth & Activity
 DISCORD_CLIENT_SECRET=
-
-# Discord Activity (Client-side SDK) - Required for Discord iframe
-# Note: This should be the same value as DISCORD_CLIENT_ID above
 NEXT_PUBLIC_DISCORD_CLIENT_ID=
 
 # Example:

--- a/.env.example
+++ b/.env.example
@@ -16,9 +16,14 @@ DATABASE_URL="file:./db.sqlite"
 BETTER_AUTH_SECRET=
 BETTER_AUTH_URL=
 
-# Discord
+# Discord OAuth (Server-side)
 DISCORD_CLIENT_ID=
 DISCORD_CLIENT_SECRET=
+
+# Discord Activity (Client-side SDK)
+# Note: This can be the same value as DISCORD_CLIENT_ID, but needs to be separate
+# because NEXT_PUBLIC_* variables are exposed to the client-side
+NEXT_PUBLIC_DISCORD_CLIENT_ID=
 
 # Example:
 # SERVERVAR="foo"

--- a/.env.example
+++ b/.env.example
@@ -16,13 +16,12 @@ DATABASE_URL="file:./db.sqlite"
 BETTER_AUTH_SECRET=
 BETTER_AUTH_URL=
 
-# Discord OAuth (Server-side)
+# Discord OAuth (Server-side) - Required for Better Auth
 DISCORD_CLIENT_ID=
 DISCORD_CLIENT_SECRET=
 
-# Discord Activity (Client-side SDK)
-# Note: This can be the same value as DISCORD_CLIENT_ID, but needs to be separate
-# because NEXT_PUBLIC_* variables are exposed to the client-side
+# Discord Activity (Client-side SDK) - Required for Discord iframe
+# Note: This should be the same value as DISCORD_CLIENT_ID above
 NEXT_PUBLIC_DISCORD_CLIENT_ID=
 
 # Example:

--- a/src/app/api/auth/discord-sdk/route.ts
+++ b/src/app/api/auth/discord-sdk/route.ts
@@ -2,9 +2,8 @@ import { env } from "~/env";
 
 export async function POST(request: Request) {
   try {
-    const { code, state } = (await request.json()) as {
+    const { code } = (await request.json()) as {
       code: string;
-      state: string;
     };
 
     if (!code) {
@@ -20,9 +19,6 @@ export async function POST(request: Request) {
       `${env.BETTER_AUTH_URL}/api/auth/callback/discord`,
     );
     callbackUrl.searchParams.set("code", code);
-    if (state) {
-      callbackUrl.searchParams.set("state", state);
-    }
 
     return Response.json({
       redirectUrl: callbackUrl.toString(),

--- a/src/app/api/auth/discord-sdk/route.ts
+++ b/src/app/api/auth/discord-sdk/route.ts
@@ -1,71 +1,24 @@
 import { env } from "~/env";
-import { auth } from "~/lib/auth/server";
 
 export async function POST(request: Request) {
   try {
-    const { code } = await request.json();
+    const { code, state } = await request.json();
 
     if (!code) {
       return Response.json({ error: "Missing authorization code" }, { status: 400 });
     }
 
-    // Exchange the authorization code for an access token
-    const tokenResponse = await fetch("https://discord.com/api/oauth2/token", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-      },
-      body: new URLSearchParams({
-        client_id: env.DISCORD_CLIENT_ID,
-        client_secret: env.DISCORD_CLIENT_SECRET,
-        grant_type: "authorization_code",
-        code,
-        redirect_uri: `${env.BETTER_AUTH_URL}/api/auth/callback/discord`,
-      }),
-    });
-
-    if (!tokenResponse.ok) {
-      const error = await tokenResponse.text();
-      console.error("Token exchange failed:", error);
-      return Response.json({ error: "Token exchange failed" }, { status: 400 });
+    // Redirect to the existing Discord callback with the authorization code
+    // This leverages the existing Discord provider in Better Auth
+    const callbackUrl = new URL(`${env.BETTER_AUTH_URL}/api/auth/callback/discord`);
+    callbackUrl.searchParams.set("code", code);
+    if (state) {
+      callbackUrl.searchParams.set("state", state);
     }
-
-    const tokenData = await tokenResponse.json();
-    const { access_token } = tokenData;
-
-    // Get user info from Discord
-    const userResponse = await fetch("https://discord.com/api/users/@me", {
-      headers: {
-        Authorization: `Bearer ${access_token}`,
-      },
-    });
-
-    if (!userResponse.ok) {
-      const error = await userResponse.text();
-      console.error("Failed to fetch user info:", error);
-      return Response.json({ error: "Failed to fetch user info" }, { status: 400 });
-    }
-
-    const userData = await userResponse.json();
-
-    // Create session by calling the auth endpoint with the user data
-    const sessionResponse = await auth.api.signInSocial({
-      body: {
-        provider: "discord",
-        providerId: userData.id,
-        email: userData.email,
-        name: userData.username,
-        image: userData.avatar 
-          ? `https://cdn.discordapp.com/avatars/${userData.id}/${userData.avatar}.png`
-          : null,
-        emailVerified: userData.verified,
-      },
-    });
 
     return Response.json({ 
-      access_token,
-      success: true,
-      user: sessionResponse.user,
+      redirectUrl: callbackUrl.toString(),
+      success: true 
     });
   } catch (error) {
     console.error("Discord SDK auth error:", error);

--- a/src/app/api/auth/discord-sdk/route.ts
+++ b/src/app/api/auth/discord-sdk/route.ts
@@ -2,23 +2,31 @@ import { env } from "~/env";
 
 export async function POST(request: Request) {
   try {
-    const { code, state } = await request.json();
+    const { code, state } = (await request.json()) as {
+      code: string;
+      state: string;
+    };
 
     if (!code) {
-      return Response.json({ error: "Missing authorization code" }, { status: 400 });
+      return Response.json(
+        { error: "Missing authorization code" },
+        { status: 400 },
+      );
     }
 
     // Redirect to the existing Discord callback with the authorization code
     // This leverages the existing Discord provider in Better Auth
-    const callbackUrl = new URL(`${env.BETTER_AUTH_URL}/api/auth/callback/discord`);
+    const callbackUrl = new URL(
+      `${env.BETTER_AUTH_URL}/api/auth/callback/discord`,
+    );
     callbackUrl.searchParams.set("code", code);
     if (state) {
       callbackUrl.searchParams.set("state", state);
     }
 
-    return Response.json({ 
+    return Response.json({
       redirectUrl: callbackUrl.toString(),
-      success: true 
+      success: true,
     });
   } catch (error) {
     console.error("Discord SDK auth error:", error);

--- a/src/app/api/auth/discord-sdk/route.ts
+++ b/src/app/api/auth/discord-sdk/route.ts
@@ -1,0 +1,74 @@
+import { env } from "~/env";
+import { auth } from "~/lib/auth/server";
+
+export async function POST(request: Request) {
+  try {
+    const { code } = await request.json();
+
+    if (!code) {
+      return Response.json({ error: "Missing authorization code" }, { status: 400 });
+    }
+
+    // Exchange the authorization code for an access token
+    const tokenResponse = await fetch("https://discord.com/api/oauth2/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        client_id: env.DISCORD_CLIENT_ID,
+        client_secret: env.DISCORD_CLIENT_SECRET,
+        grant_type: "authorization_code",
+        code,
+        redirect_uri: `${env.BETTER_AUTH_URL}/api/auth/callback/discord`,
+      }),
+    });
+
+    if (!tokenResponse.ok) {
+      const error = await tokenResponse.text();
+      console.error("Token exchange failed:", error);
+      return Response.json({ error: "Token exchange failed" }, { status: 400 });
+    }
+
+    const tokenData = await tokenResponse.json();
+    const { access_token } = tokenData;
+
+    // Get user info from Discord
+    const userResponse = await fetch("https://discord.com/api/users/@me", {
+      headers: {
+        Authorization: `Bearer ${access_token}`,
+      },
+    });
+
+    if (!userResponse.ok) {
+      const error = await userResponse.text();
+      console.error("Failed to fetch user info:", error);
+      return Response.json({ error: "Failed to fetch user info" }, { status: 400 });
+    }
+
+    const userData = await userResponse.json();
+
+    // Create session by calling the auth endpoint with the user data
+    const sessionResponse = await auth.api.signInSocial({
+      body: {
+        provider: "discord",
+        providerId: userData.id,
+        email: userData.email,
+        name: userData.username,
+        image: userData.avatar 
+          ? `https://cdn.discordapp.com/avatars/${userData.id}/${userData.avatar}.png`
+          : null,
+        emailVerified: userData.verified,
+      },
+    });
+
+    return Response.json({ 
+      access_token,
+      success: true,
+      user: sessionResponse.user,
+    });
+  } catch (error) {
+    console.error("Discord SDK auth error:", error);
+    return Response.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/components/auth/sign-in-button.tsx
+++ b/src/components/auth/sign-in-button.tsx
@@ -1,22 +1,49 @@
 "use client";
 
+import React, { useState, useEffect } from "react";
 import { Button } from "~/components/ui/button";
-import { User } from "lucide-react";
+import { User, Loader2 } from "lucide-react";
 import { signIn } from "~/lib/auth/client";
+import { isInDiscordIframe } from "~/lib/discord-sdk";
 
 export function SignInButton() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [isDiscordIframe, setIsDiscordIframe] = useState(false);
+
+  useEffect(() => {
+    // Check if we're in Discord's iframe
+    setIsDiscordIframe(isInDiscordIframe());
+  }, []);
+
   const handleSignIn = async () => {
+    setIsLoading(true);
     try {
       await signIn();
     } catch (error) {
       console.error("Sign-in failed:", error);
+    } finally {
+      setIsLoading(false);
     }
   };
 
   return (
-    <Button onClick={handleSignIn} className="w-full" size="lg">
-      <User className="h-4 w-4" />
-      Sign in with Discord
+    <Button 
+      onClick={handleSignIn} 
+      className="w-full" 
+      size="lg"
+      disabled={isLoading}
+    >
+      {isLoading ? (
+        <>
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          {isDiscordIframe ? "Authenticating with Discord..." : "Signing in..."}
+        </>
+      ) : (
+        <>
+          <User className="h-4 w-4" />
+          {isDiscordIframe ? "Sign in with Discord Activity" : "Sign in with Discord"}
+        </>
+      )}
     </Button>
   );
 }

--- a/src/env.js
+++ b/src/env.js
@@ -14,7 +14,6 @@ export const env = createEnv({
       .default("development"),
     BETTER_AUTH_SECRET: z.string(),
     BETTER_AUTH_URL: z.string().url(),
-    DISCORD_CLIENT_ID: z.string(),
     DISCORD_CLIENT_SECRET: z.string(),
   },
 
@@ -37,7 +36,6 @@ export const env = createEnv({
     NODE_ENV: process.env.NODE_ENV,
     BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET,
     BETTER_AUTH_URL: process.env.BETTER_AUTH_URL,
-    DISCORD_CLIENT_ID: process.env.DISCORD_CLIENT_ID,
     DISCORD_CLIENT_SECRET: process.env.DISCORD_CLIENT_SECRET,
     NEXT_PUBLIC_DISCORD_CLIENT_ID: process.env.NEXT_PUBLIC_DISCORD_CLIENT_ID,
   },

--- a/src/env.js
+++ b/src/env.js
@@ -24,7 +24,7 @@ export const env = createEnv({
    * `NEXT_PUBLIC_`.
    */
   client: {
-    // NEXT_PUBLIC_CLIENTVAR: z.string(),
+    NEXT_PUBLIC_DISCORD_CLIENT_ID: z.string(),
   },
 
   /**
@@ -39,7 +39,7 @@ export const env = createEnv({
     BETTER_AUTH_URL: process.env.BETTER_AUTH_URL,
     DISCORD_CLIENT_ID: process.env.DISCORD_CLIENT_ID,
     DISCORD_CLIENT_SECRET: process.env.DISCORD_CLIENT_SECRET,
-    // NEXT_PUBLIC_CLIENTVAR: process.env.NEXT_PUBLIC_CLIENTVAR,
+    NEXT_PUBLIC_DISCORD_CLIENT_ID: process.env.NEXT_PUBLIC_DISCORD_CLIENT_ID,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially

--- a/src/env.js
+++ b/src/env.js
@@ -39,7 +39,7 @@ export const env = createEnv({
     BETTER_AUTH_URL: process.env.BETTER_AUTH_URL,
     DISCORD_CLIENT_ID: process.env.DISCORD_CLIENT_ID,
     DISCORD_CLIENT_SECRET: process.env.DISCORD_CLIENT_SECRET,
-    NEXT_PUBLIC_DISCORD_CLIENT_ID: process.env.NEXT_PUBLIC_DISCORD_CLIENT_ID,
+    NEXT_PUBLIC_DISCORD_CLIENT_ID: process.env.DISCORD_CLIENT_ID,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially

--- a/src/env.js
+++ b/src/env.js
@@ -39,7 +39,7 @@ export const env = createEnv({
     BETTER_AUTH_URL: process.env.BETTER_AUTH_URL,
     DISCORD_CLIENT_ID: process.env.DISCORD_CLIENT_ID,
     DISCORD_CLIENT_SECRET: process.env.DISCORD_CLIENT_SECRET,
-    NEXT_PUBLIC_DISCORD_CLIENT_ID: process.env.DISCORD_CLIENT_ID,
+    NEXT_PUBLIC_DISCORD_CLIENT_ID: process.env.NEXT_PUBLIC_DISCORD_CLIENT_ID,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially

--- a/src/lib/auth/client.ts
+++ b/src/lib/auth/client.ts
@@ -8,7 +8,7 @@ export const signIn = async () => {
   if (isInDiscordIframe()) {
     return await signInWithDiscordSDK();
   }
-  
+
   // Use normal OAuth flow
   await authClient.signIn.social({
     provider: "discord",
@@ -18,8 +18,11 @@ export const signIn = async () => {
 export const signInWithDiscordSDK = async () => {
   try {
     // Step 1: Get authorization code from Discord SDK
-    const { code, state } = await authorizeWithDiscordSDK();
-    
+    const { code, state } = (await authorizeWithDiscordSDK()) as {
+      code: string;
+      state: string;
+    };
+
     // Step 2: Get redirect URL from our endpoint
     const response = await fetch("/.proxy/api/auth/discord-sdk", {
       method: "POST",
@@ -33,8 +36,8 @@ export const signInWithDiscordSDK = async () => {
       throw new Error("Failed to process Discord SDK authorization");
     }
 
-    const { redirectUrl } = await response.json();
-    
+    const { redirectUrl } = (await response.json()) as { redirectUrl: string };
+
     // Step 3: Navigate to the Discord callback URL
     // This will trigger the normal Discord OAuth flow in Better Auth
     window.location.href = redirectUrl;

--- a/src/lib/auth/client.ts
+++ b/src/lib/auth/client.ts
@@ -18,10 +18,7 @@ export const signIn = async () => {
 export const signInWithDiscordSDK = async () => {
   try {
     // Step 1: Get authorization code from Discord SDK
-    const { code, state } = (await authorizeWithDiscordSDK()) as {
-      code: string;
-      state: string;
-    };
+    const { code } = await authorizeWithDiscordSDK();
 
     // Step 2: Get redirect URL from our endpoint
     const response = await fetch("/.proxy/api/auth/discord-sdk", {
@@ -29,7 +26,7 @@ export const signInWithDiscordSDK = async () => {
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ code, state }),
+      body: JSON.stringify({ code }),
     });
 
     if (!response.ok) {

--- a/src/lib/auth/client.ts
+++ b/src/lib/auth/client.ts
@@ -1,11 +1,49 @@
 import { createAuthClient } from "better-auth/react";
+import { authorizeWithDiscordSDK, authenticateWithDiscordSDK, isInDiscordIframe } from "~/lib/discord-sdk";
 
 export const authClient = createAuthClient();
 
 export const signIn = async () => {
+  // Check if we're in Discord's iframe
+  if (isInDiscordIframe()) {
+    return await signInWithDiscordSDK();
+  }
+  
+  // Use normal OAuth flow
   await authClient.signIn.social({
     provider: "discord",
   });
+};
+
+export const signInWithDiscordSDK = async () => {
+  try {
+    // Step 1: Get authorization code from Discord SDK
+    const code = await authorizeWithDiscordSDK();
+    
+    // Step 2: Exchange code for access token and create session
+    const response = await fetch("/.proxy/api/auth/discord-sdk", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ code }),
+    });
+
+    if (!response.ok) {
+      throw new Error("Failed to authenticate with Discord SDK");
+    }
+
+    const { access_token } = await response.json();
+    
+    // Step 3: Authenticate with Discord SDK
+    await authenticateWithDiscordSDK(access_token);
+    
+    // Reload the page to reflect the new auth state
+    window.location.reload();
+  } catch (error) {
+    console.error("Discord SDK sign-in failed:", error);
+    throw error;
+  }
 };
 
 export const signOut = async () => {

--- a/src/lib/auth/server.ts
+++ b/src/lib/auth/server.ts
@@ -9,7 +9,7 @@ export const auth = betterAuth({
   }),
   socialProviders: {
     discord: {
-      clientId: env.DISCORD_CLIENT_ID,
+      clientId: env.NEXT_PUBLIC_DISCORD_CLIENT_ID,
       clientSecret: env.DISCORD_CLIENT_SECRET,
     },
   },

--- a/src/lib/discord-sdk.ts
+++ b/src/lib/discord-sdk.ts
@@ -5,20 +5,25 @@ import { env } from "~/env";
 
 let discordSdk: DiscordSDK | null = null;
 
-export const getDiscordSDK = () => {
+export const getDiscordSDK = (): DiscordSDK => {
+  // Validate client ID
+  if (typeof env.NEXT_PUBLIC_DISCORD_CLIENT_ID !== "string") {
+    throw new Error("Must specify NEXT_PUBLIC_DISCORD_CLIENT_ID");
+  }
+
   // Initialize the Discord SDK only once
   discordSdk ??= new DiscordSDK(env.NEXT_PUBLIC_DISCORD_CLIENT_ID);
   return discordSdk;
 };
 
-export const isInDiscordIframe = () => {
+export const isInDiscordIframe = (): boolean => {
   if (typeof window === "undefined") return false;
 
   // Check if we're in Discord's iframe by checking the hostname
   return window.location.hostname.endsWith(".discordsays.com");
 };
 
-export const setupDiscordSDK = async () => {
+export const setupDiscordSDK = async (): Promise<DiscordSDK> => {
   const sdk = getDiscordSDK();
 
   try {
@@ -31,7 +36,7 @@ export const setupDiscordSDK = async () => {
   }
 };
 
-export const authorizeWithDiscordSDK = async () => {
+export const authorizeWithDiscordSDK = async (): Promise<{ code: string }> => {
   const sdk = await setupDiscordSDK();
 
   try {
@@ -41,7 +46,13 @@ export const authorizeWithDiscordSDK = async () => {
       response_type: "code",
       state: "",
       prompt: "none",
-      scope: ["identify", "email"],
+      scope: [
+        "identify",
+        "email",
+        // Add other scopes as needed for Discord activities
+        // "applications.commands",
+        // "rpc.activities.write",
+      ],
     });
 
     return { code };

--- a/src/lib/discord-sdk.ts
+++ b/src/lib/discord-sdk.ts
@@ -38,7 +38,7 @@ export const authorizeWithDiscordSDK = async () => {
   
   try {
     // Pop open the OAuth permission modal and request for access to scopes
-    const { code } = await sdk.commands.authorize({
+    const { code, state } = await sdk.commands.authorize({
       client_id: env.NEXT_PUBLIC_DISCORD_CLIENT_ID,
       response_type: "code",
       state: "",
@@ -46,25 +46,10 @@ export const authorizeWithDiscordSDK = async () => {
       scope: ["identify", "email"],
     });
     
-    return code;
+    return { code, state };
   } catch (error) {
     console.error("Discord SDK authorization failed:", error);
     throw error;
   }
 };
 
-export const authenticateWithDiscordSDK = async (accessToken: string) => {
-  const sdk = await setupDiscordSDK();
-  
-  try {
-    // Authenticate with Discord client (using the access_token)
-    const auth = await sdk.commands.authenticate({
-      access_token: accessToken,
-    });
-    
-    return auth;
-  } catch (error) {
-    console.error("Discord SDK authentication failed:", error);
-    throw error;
-  }
-};

--- a/src/lib/discord-sdk.ts
+++ b/src/lib/discord-sdk.ts
@@ -36,7 +36,7 @@ export const authorizeWithDiscordSDK = async () => {
 
   try {
     // Pop open the OAuth permission modal and request for access to scopes
-    const result = await sdk.commands.authorize({
+    const { code } = await sdk.commands.authorize({
       client_id: env.NEXT_PUBLIC_DISCORD_CLIENT_ID,
       response_type: "code",
       state: "",
@@ -44,10 +44,7 @@ export const authorizeWithDiscordSDK = async () => {
       scope: ["identify", "email"],
     });
 
-    return {
-      code: result.code,
-      state: (result.state as string) ?? "",
-    };
+    return { code };
   } catch (error) {
     console.error("Discord SDK authorization failed:", error);
     throw error;

--- a/src/lib/discord-sdk.ts
+++ b/src/lib/discord-sdk.ts
@@ -46,7 +46,7 @@ export const authorizeWithDiscordSDK = async () => {
 
     return {
       code: result.code,
-      state: result.state || "",
+      state: (result.state as string) ?? "",
     };
   } catch (error) {
     console.error("Discord SDK authorization failed:", error);

--- a/src/lib/discord-sdk.ts
+++ b/src/lib/discord-sdk.ts
@@ -36,7 +36,7 @@ export const authorizeWithDiscordSDK = async () => {
 
   try {
     // Pop open the OAuth permission modal and request for access to scopes
-    const { code } = await sdk.commands.authorize({
+    const result = await sdk.commands.authorize({
       client_id: env.NEXT_PUBLIC_DISCORD_CLIENT_ID,
       response_type: "code",
       state: "",
@@ -44,7 +44,10 @@ export const authorizeWithDiscordSDK = async () => {
       scope: ["identify", "email"],
     });
 
-    return { code };
+    return {
+      code: result.code,
+      state: result.state || "",
+    };
   } catch (error) {
     console.error("Discord SDK authorization failed:", error);
     throw error;

--- a/src/lib/discord-sdk.ts
+++ b/src/lib/discord-sdk.ts
@@ -6,23 +6,21 @@ import { env } from "~/env";
 let discordSdk: DiscordSDK | null = null;
 
 export const getDiscordSDK = () => {
-  if (!discordSdk) {
-    // Initialize the Discord SDK only once
-    discordSdk = new DiscordSDK(env.NEXT_PUBLIC_DISCORD_CLIENT_ID);
-  }
+  // Initialize the Discord SDK only once
+  discordSdk ??= new DiscordSDK(env.NEXT_PUBLIC_DISCORD_CLIENT_ID);
   return discordSdk;
 };
 
 export const isInDiscordIframe = () => {
   if (typeof window === "undefined") return false;
-  
+
   // Check if we're in Discord's iframe by checking the hostname
   return window.location.hostname.endsWith(".discordsays.com");
 };
 
 export const setupDiscordSDK = async () => {
   const sdk = getDiscordSDK();
-  
+
   try {
     // Wait for READY payload from the discord client
     await sdk.ready();
@@ -35,21 +33,20 @@ export const setupDiscordSDK = async () => {
 
 export const authorizeWithDiscordSDK = async () => {
   const sdk = await setupDiscordSDK();
-  
+
   try {
     // Pop open the OAuth permission modal and request for access to scopes
-    const { code, state } = await sdk.commands.authorize({
+    const { code } = await sdk.commands.authorize({
       client_id: env.NEXT_PUBLIC_DISCORD_CLIENT_ID,
       response_type: "code",
       state: "",
       prompt: "none",
       scope: ["identify", "email"],
     });
-    
-    return { code, state };
+
+    return { code };
   } catch (error) {
     console.error("Discord SDK authorization failed:", error);
     throw error;
   }
 };
-

--- a/src/lib/discord-sdk.ts
+++ b/src/lib/discord-sdk.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { DiscordSDK } from "@discord/embedded-app-sdk";
+import { env } from "~/env";
+
+let discordSdk: DiscordSDK | null = null;
+
+export const getDiscordSDK = () => {
+  if (!discordSdk) {
+    // Initialize the Discord SDK only once
+    discordSdk = new DiscordSDK(env.NEXT_PUBLIC_DISCORD_CLIENT_ID);
+  }
+  return discordSdk;
+};
+
+export const isInDiscordIframe = () => {
+  if (typeof window === "undefined") return false;
+  
+  // Check if we're in Discord's iframe by checking the hostname
+  return window.location.hostname.endsWith(".discordsays.com");
+};
+
+export const setupDiscordSDK = async () => {
+  const sdk = getDiscordSDK();
+  
+  try {
+    // Wait for READY payload from the discord client
+    await sdk.ready();
+    return sdk;
+  } catch (error) {
+    console.error("Failed to initialize Discord SDK:", error);
+    throw error;
+  }
+};
+
+export const authorizeWithDiscordSDK = async () => {
+  const sdk = await setupDiscordSDK();
+  
+  try {
+    // Pop open the OAuth permission modal and request for access to scopes
+    const { code } = await sdk.commands.authorize({
+      client_id: env.NEXT_PUBLIC_DISCORD_CLIENT_ID,
+      response_type: "code",
+      state: "",
+      prompt: "none",
+      scope: ["identify", "email"],
+    });
+    
+    return code;
+  } catch (error) {
+    console.error("Discord SDK authorization failed:", error);
+    throw error;
+  }
+};
+
+export const authenticateWithDiscordSDK = async (accessToken: string) => {
+  const sdk = await setupDiscordSDK();
+  
+  try {
+    // Authenticate with Discord client (using the access_token)
+    const auth = await sdk.commands.authenticate({
+      access_token: accessToken,
+    });
+    
+    return auth;
+  } catch (error) {
+    console.error("Discord SDK authentication failed:", error);
+    throw error;
+  }
+};


### PR DESCRIPTION
Implement Discord SDK authentication for embedded Discord Activities to bypass CSP restrictions.

The traditional OAuth flow is blocked by Discord's Content Security Policy when embedded in an iframe. This PR introduces a flow that uses the Discord SDK's `authorize` command to obtain the OAuth code, then redirects to the existing Better Auth Discord callback, allowing the application to authenticate within the Discord Activity environment without violating CSP.